### PR TITLE
Fix ohai plugin. Fixes #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 This file is used to list changes made in each version of the certbot-exec cookbook.
 
-# 0.1.0
+# 0.1.2
 
-Initial release.
+- Fix ohai plugin so that it works.
 
 # 0.1.1
 
 - Add `package_list` function to enable "hooking" into to add packages to be installed. 
+
+# 0.1.0
+
+Initial release.
+

--- a/files/default/certbot.rb
+++ b/files/default/certbot.rb
@@ -42,7 +42,12 @@ Ohai.plugin :Certbot do
       @ssl_dir = ssl_dir
       @ssl_cert_path = File.join ssl_dir, 'fullchain.pem'
       @ssl_key_path = File.join ssl_dir, 'privkey.pem'
-      @cert = OpenSSL::X509::Certificate.new(File.read(@ssl_file))
+      begin
+        @cert = OpenSSL::X509::Certificate.new(File.read(ssl_cert_path))
+      rescue => e
+        puts '[!] certbot-exec Ohai Plugin - Error loading SSL Certificate: #{ssl_cert_path}'
+        puts "[!] #{e}"
+      end
     end
 
     def cert_name

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'qubitrenegade@protonmail.com'
 license           'MIT'
 description       'Installs/Configures certbot-exec'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.1.1'
+version           '0.1.2'
 chef_version      '>= 13.0'
 
 depends 'ohai'


### PR DESCRIPTION
This fixes the file read by CertbotCert class in the ohai plugin.

This adds an error message... but does not fail as that seems to be how Ohai operates (i.e.: we don't want to cause the whole ohai run to fail).